### PR TITLE
Fix ARM bad instructions in OSX toolchain

### DIFF
--- a/configs/darwin-arm-v7/.config
+++ b/configs/darwin-arm-v7/.config
@@ -1,10 +1,10 @@
 #
 # Automatically generated make config: don't edit
 # crosstool-NG 1.21.0 Configuration
-# Thu Jul 16 17:57:02 2015
+# Tue Aug 18 12:06:25 2015
 #
 CT_CONFIGURE_has_make381=y
-CT_CONFIGURE_has_svn=y
+CT_CONFIGURE_has_xz=y
 CT_MODULES=y
 
 #
@@ -148,7 +148,7 @@ CT_ARCH_SUFFIX=""
 #
 # Generic target options
 #
-CT_MULTILIB=y
+# CT_MULTILIB is not set
 CT_ARCH_USE_MMU=y
 CT_ARCH_ENDIAN="little"
 
@@ -165,7 +165,7 @@ CT_ARCH_FLOAT="softfp"
 CT_ARCH_ARM_MODE="arm"
 CT_ARCH_ARM_MODE_ARM=y
 # CT_ARCH_ARM_MODE_THUMB is not set
-CT_ARCH_ARM_INTERWORKING=y
+# CT_ARCH_ARM_INTERWORKING is not set
 CT_ARCH_ARM_EABI_FORCE=y
 CT_ARCH_ARM_EABI=y
 
@@ -257,25 +257,34 @@ CT_BINUTILS_binutils=y
 # GNU binutils
 #
 # CT_CC_BINUTILS_SHOW_LINARO is not set
-# CT_BINUTILS_V_2_25 is not set
+CT_BINUTILS_V_2_25=y
 # CT_BINUTILS_V_2_24 is not set
 # CT_BINUTILS_V_2_23_2 is not set
 # CT_BINUTILS_V_2_23_1 is not set
 # CT_BINUTILS_V_2_22 is not set
 # CT_BINUTILS_V_2_21_53 is not set
 # CT_BINUTILS_V_2_21_1a is not set
-CT_BINUTILS_V_2_20_1a=y
+# CT_BINUTILS_V_2_20_1a is not set
 # CT_BINUTILS_V_2_19_1a is not set
 # CT_BINUTILS_V_2_18a is not set
-CT_BINUTILS_VERSION="2.20.1a"
+CT_BINUTILS_VERSION="2.25"
+CT_BINUTILS_2_25_or_later=y
+CT_BINUTILS_2_24_or_later=y
+CT_BINUTILS_2_23_or_later=y
+CT_BINUTILS_2_22_or_later=y
+CT_BINUTILS_2_21_or_later=y
 CT_BINUTILS_2_20_or_later=y
 CT_BINUTILS_2_19_or_later=y
 CT_BINUTILS_2_18_or_later=y
 CT_BINUTILS_HAS_HASH_STYLE=y
+CT_BINUTILS_HAS_GOLD=y
 CT_BINUTILS_GOLD_SUPPORTS_ARCH=y
+CT_BINUTILS_HAS_PLUGINS=y
 CT_BINUTILS_HAS_PKGVERSION_BUGURL=y
 CT_BINUTILS_FORCE_LD_BFD=y
 CT_BINUTILS_LINKER_LD=y
+# CT_BINUTILS_LINKER_LD_GOLD is not set
+# CT_BINUTILS_LINKER_GOLD_LD is not set
 CT_BINUTILS_LINKERS_LIST="ld"
 CT_BINUTILS_LINKER_DEFAULT="bfd"
 CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
@@ -552,9 +561,4 @@ CT_MPC_VERSION="1.0.2"
 #
 # READ HELP before you say 'Y' below !!!
 #
-CT_COMP_TOOLS=y
-# CT_COMP_TOOLS_make is not set
-# CT_COMP_TOOLS_m4 is not set
-# CT_COMP_TOOLS_autoconf is not set
-# CT_COMP_TOOLS_automake is not set
-# CT_COMP_TOOLS_libtool is not set
+# CT_COMP_TOOLS is not set


### PR DESCRIPTION
This config is similar to the linux one, except:
- Clang needs "-fbracket-depth=1024" [1]
- OSX dislikes static binaries [2]

[1] https://llvm.org/bugs/show_bug.cgi?id=19650
[2] https://developer.apple.com/library/mac/qa/qa1118/_index.html
